### PR TITLE
fix(ui): keep left toolbar from overlapping app logo on ultrawide screens

### DIFF
--- a/web/src/ui/Main.module.css
+++ b/web/src/ui/Main.module.css
@@ -131,7 +131,7 @@
     display: block;
     position: absolute;
     left: 25px;
-    top: 15%;
+    top: max(15%, 7rem);
   }
 
   .bottleft {
@@ -200,7 +200,7 @@
     z-index: 11;
   }
   .left {
-    top: 8%;
+    top: max(8%, 7rem);
   }
 }
 
@@ -215,7 +215,7 @@
   }
 
   .left {
-    top: 15%;
+    top: max(15%, 7rem);
   }
 }
 
@@ -237,7 +237,7 @@
 
 @media screen and (min-width: 2560px) and (orientation: landscape) {
   .left {
-    top: 5%;
+    top: max(5%, 7rem);
   }
   .settings {
     top: 4rem;

--- a/web/src/ui/Main.module.test.js
+++ b/web/src/ui/Main.module.test.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+const REM_TO_PX = 16;
+const LOGO_AREA_BOTTOM_PX = 101;
+const VIEWPORT_HEIGHTS_PX = [600, 720, 768, 900, 1032, 1080, 1440];
+
+function resolveLengthToPx(token, viewportHeightPx) {
+  const value = token.trim();
+  const asMax = value.match(/^max\((.*)\)$/i);
+  if (asMax) {
+    return Math.max(...asMax[1].split(',').map((part) => resolveLengthToPx(part, viewportHeightPx)));
+  }
+  if (value.endsWith('rem')) {
+    return parseFloat(value) * REM_TO_PX;
+  }
+  if (value.endsWith('px')) {
+    return parseFloat(value);
+  }
+  if (value.endsWith('%')) {
+    return (parseFloat(value) / 100) * viewportHeightPx;
+  }
+  throw new Error(`Unsupported length in .left top: "${value}"`);
+}
+
+function collectLeftToolbarTops() {
+  const css = fs.readFileSync(path.join(currentDir, 'Main.module.css'), 'utf8');
+  const leftRule = /\.left\s*\{([^}]*)\}/g;
+  const tops = [];
+  let match;
+  while ((match = leftRule.exec(css)) !== null) {
+    const top = match[1].match(/top:\s*([^;]+);/);
+    if (top) {
+      tops.push(top[1].trim());
+    }
+  }
+  return tops;
+}
+
+describe('Main layout: left toolbar vs app logo (issue #237)', () => {
+  const tops = collectLeftToolbarTops();
+
+  it('declares a vertical offset for the left toolbar', () => {
+    expect(tops.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the left toolbar below the logo on every tested viewport height', () => {
+    tops.forEach((top) => {
+      VIEWPORT_HEIGHTS_PX.forEach((viewportHeightPx) => {
+        expect(resolveLengthToPx(top, viewportHeightPx)).toBeGreaterThanOrEqual(LOGO_AREA_BOTTOM_PX);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **#237** — on ultrawide screens the left control panel (top buttons) overlaps the application logo.

### Root cause
The left toolbar (`.left`) is absolutely positioned with a **viewport-height percentage** `top`. On ultrawide the `@media (min-width: 2560px) and (orientation: landscape)` rule resolves `top: 5%` to ~50px, while the app logo occupies roughly `y 32–101px`. The toolbar's first buttons therefore land on top of the logo. Percentages of viewport height don't account for the fixed-height header, so they collapse below the logo on wide-but-short viewports.

### Fix
Guard every `.left` `top` with `max(<percent>, 7rem)`. `7rem` (112px) clears the logo/header, and the original percentage still wins on taller viewports — so there is no change on normal desktop sizes.

### Verification
Measured live (bounding boxes) after the change — no overlap at the sizes that previously broke:

| Viewport | logo bottom | toolbar top | overlap |
|---|---|---|---|
| 3440×1032 | 101px | 112px | none |
| 2560×937 | 101px | 112px | none |
| 1440×757 | 101px | 114px | none |

Before the fix, 3440×1032 put the toolbar top at 52px (≈49px overlap).

### Tests
Adds `web/src/ui/Main.module.test.js`: it parses `Main.module.css`, resolves each `.left` `top` (supporting `max()`, `%`, `rem`) across a range of viewport heights and asserts the toolbar stays below the logo. Confirmed it **fails** on the old `top: 5%` (30px < 101px) and **passes** with the fix. `npm run lint` / Prettier are clean.

Closes #237