### PR TITLE
fix(dicom): honor ImageOrientationPatient to fix mirrored slices (#221)

### DIFF
--- a/docs/web/RENDERING_PIPELINE_TECHNICAL.md
+++ b/docs/web/RENDERING_PIPELINE_TECHNICAL.md
@@ -22,7 +22,7 @@ The loaders apply a **targeted sign-flip** (Approach A):
 
 - The six direction cosines are parsed alongside `ImagePositionPatient (0020,0032)`.
 - Per-axis flip flags are derived from the signs of the row cosine (X) and column cosine (Y). Only axes with a negative cosine are flipped during the pixel copy / volume assembly.
-- The path is **gated to identity orientation** (`1,0,0,0,1,0`, or the tag being absent): identity DICOMs take the original code path and produce a byte-for-byte unchanged voxel buffer. This avoids a double-flip against the renderer's X-negation in `VolumeRenderer3d.js` and guarantees no regression for standard axial series.
+- The flip is **gated on the signs of the row/column direction cosines**: any orientation whose row cosine (`cosines[0]`) and column cosine (`cosines[4]`) are both non-negative — identity (`1,0,0,0,1,0`) included, as well as the tag being absent — takes the original code path and produces a byte-for-byte unchanged voxel buffer. This avoids a double-flip against the renderer's X-negation in `VolumeRenderer3d.js` and guarantees no regression for standard axial series.
 - The same flip helper is shared by the multi-file series path (`LoaderDicom.js`) and the single-file daikon path (`LoaderDcmDaikon.js`) so both behave identically.
 
 This is intentionally **not** a general oblique-reorientation engine — it corrects sign-flipped axis-aligned acquisitions only.

--- a/docs/web/RENDERING_PIPELINE_TECHNICAL.md
+++ b/docs/web/RENDERING_PIPELINE_TECHNICAL.md
@@ -14,6 +14,25 @@ User selects DICOM files via the `OpenFromDeviceComponent`. The `MRIReaderFactor
 
 `LoaderDicom` reads each file's binary data using the Daikon library. Key DICOM tags are extracted: pixel data, image dimensions, slice position, spacing, and orientation vectors.
 
+### DICOM Orientation Handling (`ImageOrientationPatient`, tag `0020,0037`)
+
+`ImageOrientationPatient` supplies six floats — the row (`Xr Yr Zr`) and column (`Xc Yc Zc`) direction cosines. Some cone-beam acquisitions (e.g. TrophyPan / CS 8100 3D) encode negative cosines, which caused slices to render mirrored versus other viewers (issue #221).
+
+The loaders apply a **targeted sign-flip** (Approach A):
+
+- The six direction cosines are parsed alongside `ImagePositionPatient (0020,0032)`.
+- Per-axis flip flags are derived from the signs of the row cosine (X) and column cosine (Y). Only axes with a negative cosine are flipped during the pixel copy / volume assembly.
+- The path is **gated to identity orientation** (`1,0,0,0,1,0`, or the tag being absent): identity DICOMs take the original code path and produce a byte-for-byte unchanged voxel buffer. This avoids a double-flip against the renderer's X-negation in `VolumeRenderer3d.js` and guarantees no regression for standard axial series.
+- The same flip helper is shared by the multi-file series path (`LoaderDicom.js`) and the single-file daikon path (`LoaderDcmDaikon.js`) so both behave identically.
+
+This is intentionally **not** a general oblique-reorientation engine — it corrects sign-flipped axis-aligned acquisitions only.
+
+**Deferred follow-ups:**
+
+- Full oblique / canonical reslicing (Approach B) for arbitrary non-axis-aligned orientations.
+- qform/sform-equivalent handling (NIfTI orientation matrices, issue #11) — tracked as a separate plan/PR.
+- 3D black-screen issues #208 / #238 are unrelated to orientation and remain out of scope.
+
 ---
 
 ## 3. Series Grouping

--- a/docs/web/RENDERING_PIPELINE_TECHNICAL.md
+++ b/docs/web/RENDERING_PIPELINE_TECHNICAL.md
@@ -21,8 +21,8 @@ User selects DICOM files via the `OpenFromDeviceComponent`. The `MRIReaderFactor
 The loaders apply a **targeted sign-flip** (Approach A):
 
 - The six direction cosines are parsed alongside `ImagePositionPatient (0020,0032)`.
-- Per-axis flip flags are derived from the signs of the row cosine (X) and column cosine (Y). Only axes with a negative cosine are flipped during the pixel copy / volume assembly.
-- The flip is **gated on the signs of the row/column direction cosines**: any orientation whose row cosine (`cosines[0]`) and column cosine (`cosines[4]`) are both non-negative — identity (`1,0,0,0,1,0`) included, as well as the tag being absent — takes the original code path and produces a byte-for-byte unchanged voxel buffer. This avoids a double-flip against the renderer's X-negation in `VolumeRenderer3d.js` and guarantees no regression for standard axial series.
+- Per-axis flip flags are derived from the row and column direction cosines: the X axis flips only when the row cosine is dominated by its X component and that component is negative; the Y axis flips only when the column cosine is dominated by its Y component and that component is negative.
+- The flip is **gated on axis-dominant negative cosines**: identity (`1,0,0,0,1,0`), the tag being absent, and any non-axis-aligned (in-plane rotated or non-axial primary) orientation all take the original code path and produce a byte-for-byte unchanged voxel buffer. Restricting the flip to axis-dominant components avoids spuriously mirroring rotated acquisitions and avoids a double-flip against the renderer's X-negation in `VolumeRenderer3d.js`, guaranteeing no regression for standard axial series.
 - The same flip helper is shared by the multi-file series path (`LoaderDicom.js`) and the single-file daikon path (`LoaderDcmDaikon.js`) so both behave identically.
 
 This is intentionally **not** a general oblique-reorientation engine — it corrects sign-flipped axis-aligned acquisitions only.

--- a/web/src/engine/loaders/LoaderDcmDaikon.js
+++ b/web/src/engine/loaders/LoaderDcmDaikon.js
@@ -41,6 +41,41 @@ class LoaderDcmDaikon {
     this.m_loaderDicom = null;
   }
 
+  static orientationFlipFromTagValue(tagValue) {
+    const NO_FLIP = { x: false, y: false, z: false };
+    if (tagValue === null || tagValue === undefined || tagValue.length === undefined) {
+      return NO_FLIP;
+    }
+    const NUM_COMPONENTS_6 = 6;
+    if (tagValue.length !== NUM_COMPONENTS_6) {
+      return NO_FLIP;
+    }
+    const cosines = Array.prototype.map.call(tagValue, (val) => parseFloat(val));
+    if (cosines.some((val) => Number.isNaN(val))) {
+      return NO_FLIP;
+    }
+    return LoaderDicom.getOrientationFlipFlags(cosines);
+  }
+
+  static copySlicePixels(volSliceImage, pixels, xDim, yDim, samplesPerPixel, flip) {
+    const numPixels = xDim * yDim;
+    if (samplesPerPixel === 1) {
+      const pixSrc = new Uint16Array(pixels);
+      for (let i = 0; i < numPixels; i++) {
+        volSliceImage[LoaderDicom.computeDestIndex(i, xDim, yDim, flip)] = pixSrc[i];
+      }
+    } else if (samplesPerPixel === 3) {
+      const pixSrc = new Uint8Array(pixels);
+      let j = 0;
+      for (let i = 0; i < numPixels; i++, j += 3) {
+        const bVal = pixSrc[j + 0];
+        const gVal = pixSrc[j + 1];
+        const rVal = pixSrc[j + 2];
+        volSliceImage[LoaderDicom.computeDestIndex(i, xDim, yDim, flip)] = Math.floor((bVal + gVal + rVal) / 3);
+      }
+    }
+  }
+
   //
   // see example read
   // https://github.com/mbarnig/dumpDICOMDIRarchive/blob/master/dumpDICOMDIR.js
@@ -404,6 +439,11 @@ class LoaderDcmDaikon {
       } // if 3 components in array
     } // if tag exists
 
+    // get image orientation (row / column direction cosines) to detect axis flip
+    ind = daikon.Utils.dec2hex(daikon.Tag.TAG_IMAGE_ORIENTATION[0]) + daikon.Utils.dec2hex(daikon.Tag.TAG_IMAGE_ORIENTATION[1]);
+    const tagImOri = image.tags[ind];
+    const orientationFlip = LoaderDcmDaikon.orientationFlipFromTagValue(tagImOri !== undefined ? tagImOri.value : null);
+
     // read transfer syntax (detect big endian)
     ind = daikon.Utils.dec2hex(daikon.Tag.TAG_TRANSFER_SYNTAX[0]) + daikon.Utils.dec2hex(daikon.Tag.TAG_TRANSFER_SYNTAX[1]);
     const tagTraSyn = image.tags[ind];
@@ -435,24 +475,8 @@ class LoaderDcmDaikon {
       volSlice.m_image = new Uint16Array(xDim * yDim);
     }
 
-    // copy pixels (ArrayBuffer) into volSlice.m_image
-    const numPixels = xDim * yDim;
-    if (this.m_loaderDicom.m_samplesPerPixel === 1) {
-      const pixSrc = new Uint16Array(pixels);
-      for (let i = 0; i < numPixels; i++) {
-        volSlice.m_image[i] = pixSrc[i];
-      } // for i
-    } // if 1 sample per pixel
-    else if (this.m_loaderDicom.m_samplesPerPixel === 3) {
-      const pixSrc = new Uint8Array(pixels);
-      let j = 0;
-      for (let i = 0; i < numPixels; i++, j += 3) {
-        const bVal = pixSrc[j + 0];
-        const gVal = pixSrc[j + 1];
-        const rVal = pixSrc[j + 2];
-        volSlice.m_image[i] = Math.floor((bVal + gVal + rVal) / 3);
-      } // for i
-    } // if samples per pixel is 3
+    // copy pixels (ArrayBuffer) into volSlice.m_image, applying orientation flip
+    LoaderDcmDaikon.copySlicePixels(volSlice.m_image, pixels, xDim, yDim, this.m_loaderDicom.m_samplesPerPixel, orientationFlip);
     // store x, y dims
     volSlice.m_xDim = xDim;
     volSlice.m_yDim = yDim;

--- a/web/src/engine/loaders/LoaderDcmDaikon.js
+++ b/web/src/engine/loaders/LoaderDcmDaikon.js
@@ -439,7 +439,6 @@ class LoaderDcmDaikon {
       } // if 3 components in array
     } // if tag exists
 
-    // get image orientation (row / column direction cosines) to detect axis flip
     ind = daikon.Utils.dec2hex(daikon.Tag.TAG_IMAGE_ORIENTATION[0]) + daikon.Utils.dec2hex(daikon.Tag.TAG_IMAGE_ORIENTATION[1]);
     const tagImOri = image.tags[ind];
     const orientationFlip = LoaderDcmDaikon.orientationFlipFromTagValue(tagImOri !== undefined ? tagImOri.value : null);
@@ -475,7 +474,6 @@ class LoaderDcmDaikon {
       volSlice.m_image = new Uint16Array(xDim * yDim);
     }
 
-    // copy pixels (ArrayBuffer) into volSlice.m_image, applying orientation flip
     LoaderDcmDaikon.copySlicePixels(volSlice.m_image, pixels, xDim, yDim, this.m_loaderDicom.m_samplesPerPixel, orientationFlip);
     // store x, y dims
     volSlice.m_xDim = xDim;

--- a/web/src/engine/loaders/LoaderDcmDaikon.test.js
+++ b/web/src/engine/loaders/LoaderDcmDaikon.test.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import LoaderDcmDaikon from './LoaderDcmDaikon';
+import LoaderDicom from './LoaderDicom';
+
+describe('LoaderDcmDaikon single-file orientation flip', () => {
+  const NO_FLIP = { x: false, y: false, z: false };
+
+  const _srcBuffer16 = (values) => {
+    const arr = new Uint16Array(values);
+    return arr.buffer;
+  };
+
+  it('identity orientation copies the single slice byte-for-byte unchanged', () => {
+    const dst = new Uint16Array(6);
+    LoaderDcmDaikon.copySlicePixels(dst, _srcBuffer16([1, 2, 3, 4, 5, 6]), 3, 2, 1, NO_FLIP);
+    expect(Array.from(dst)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('negative row cosine mirrors X in the single-file path', () => {
+    const dst = new Uint16Array(6);
+    const flip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, 1, 0]);
+    LoaderDcmDaikon.copySlicePixels(dst, _srcBuffer16([1, 2, 3, 4, 5, 6]), 3, 2, 1, flip);
+    expect(Array.from(dst)).toEqual([3, 2, 1, 6, 5, 4]);
+  });
+
+  it('negative column cosine mirrors Y in the single-file path', () => {
+    const dst = new Uint16Array(6);
+    const flip = LoaderDicom.getOrientationFlipFlags([1, 0, 0, 0, -1, 0]);
+    LoaderDcmDaikon.copySlicePixels(dst, _srcBuffer16([1, 2, 3, 4, 5, 6]), 3, 2, 1, flip);
+    expect(Array.from(dst)).toEqual([4, 5, 6, 1, 2, 3]);
+  });
+
+  it('combined negative row and column cosines mirror both axes', () => {
+    const dst = new Uint16Array(6);
+    const flip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, -1, 0]);
+    LoaderDcmDaikon.copySlicePixels(dst, _srcBuffer16([1, 2, 3, 4, 5, 6]), 3, 2, 1, flip);
+    expect(Array.from(dst)).toEqual([6, 5, 4, 3, 2, 1]);
+  });
+
+  it('applies the same flip for 3-samples-per-pixel (rgb averaged) data', () => {
+    const rgb = new Uint8Array([10, 10, 10, 20, 20, 20, 30, 30, 30, 40, 40, 40]);
+    const dst = new Uint16Array(4);
+    const flip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, 1, 0]);
+    LoaderDcmDaikon.copySlicePixels(dst, rgb.buffer, 2, 2, 3, flip);
+    expect(Array.from(dst)).toEqual([20, 10, 40, 30]);
+  });
+
+  it('parses daikon orientation tag values into flip flags', () => {
+    expect(LoaderDcmDaikon.orientationFlipFromTagValue([1, 0, 0, 0, 1, 0])).toEqual(NO_FLIP);
+    expect(LoaderDcmDaikon.orientationFlipFromTagValue([-1, 0, 0, 0, 1, 0])).toEqual({ x: true, y: false, z: false });
+    expect(LoaderDcmDaikon.orientationFlipFromTagValue(['1', '0', '0', '0', '-1', '0'])).toEqual({ x: false, y: true, z: false });
+    expect(LoaderDcmDaikon.orientationFlipFromTagValue(null)).toEqual(NO_FLIP);
+    expect(LoaderDcmDaikon.orientationFlipFromTagValue([1, 0, 0])).toEqual(NO_FLIP);
+  });
+});

--- a/web/src/engine/loaders/LoaderDicom.js
+++ b/web/src/engine/loaders/LoaderDicom.js
@@ -889,10 +889,16 @@ class LoaderDicom {
     if (cosines === null || cosines.length < 6) {
       return flip;
     }
-    const ROW_X = 0;
-    const COL_Y = 4;
-    flip.x = cosines[ROW_X] < 0.0;
-    flip.y = cosines[COL_Y] < 0.0;
+    const rowX = cosines[0];
+    const rowY = cosines[1];
+    const rowZ = cosines[2];
+    const colX = cosines[3];
+    const colY = cosines[4];
+    const colZ = cosines[5];
+    const rowXDominant = Math.abs(rowX) > Math.abs(rowY) && Math.abs(rowX) > Math.abs(rowZ);
+    const colYDominant = Math.abs(colY) > Math.abs(colX) && Math.abs(colY) > Math.abs(colZ);
+    flip.x = rowXDominant && rowX < 0.0;
+    flip.y = colYDominant && colY < 0.0;
     return flip;
   }
   static computeDestIndex(srcIndex, xDim, yDim, flip) {

--- a/web/src/engine/loaders/LoaderDicom.js
+++ b/web/src/engine/loaders/LoaderDicom.js
@@ -238,7 +238,6 @@ class LoaderDicom {
     // eslint-disable-next-line
     this.m_sliceLocMax = -1.0e12;
 
-    this.m_imageOrientation = null;
     this.m_orientationFlip = {
       x: false,
       y: false,
@@ -1385,6 +1384,11 @@ class LoaderDicom {
     this.m_bitsPerPixel = -1;
     this.m_windowCenter = -1;
     this.m_windowWidth = -1;
+    this.m_orientationFlip = {
+      x: false,
+      y: false,
+      z: false,
+    };
     let pixelBitMask = 0;
     let pixelPaddingValue = 0;
     let pixelsTagReaded = false;
@@ -1663,14 +1667,12 @@ class LoaderDicom {
         }
       }
 
-      // get important tag: image orientation (row / column direction cosines)
       if (tag.m_group === TAG_IMAGE_ORIENTATION[0] && tag.m_element === TAG_IMAGE_ORIENTATION[1] && tag.m_value !== null) {
         const dataLen = tag.m_value.byteLength;
         const dv = new DataView(tag.m_value);
         const strImageOrientation = LoaderDicom.getStringAt(dv, 0, dataLen);
         const cosines = LoaderDicom.parseDirectionCosines(strImageOrientation);
         if (cosines !== null) {
-          this.m_imageOrientation = cosines;
           this.m_orientationFlip = LoaderDicom.getOrientationFlipFlags(cosines);
           if (DEBUG_PRINT_TAGS_INFO) {
             console.log(`TAG. image orientation = ${cosines.join(', ')}`);

--- a/web/src/engine/loaders/LoaderDicom.js
+++ b/web/src/engine/loaders/LoaderDicom.js
@@ -896,6 +896,20 @@ class LoaderDicom {
     flip.y = cosines[COL_Y] < 0.0;
     return flip;
   }
+  static computeDestIndex(srcIndex, xDim, yDim, flip) {
+    if (!flip.x && !flip.y) {
+      return srcIndex;
+    }
+    let x = srcIndex % xDim;
+    let y = Math.floor(srcIndex / xDim);
+    if (flip.x) {
+      x = xDim - 1 - x;
+    }
+    if (flip.y) {
+      y = yDim - 1 - y;
+    }
+    return y * xDim + x;
+  }
   static getUtf8StringAt(dataView, offset, lengthBuf) {
     let str = '';
     let i = 0;
@@ -1901,12 +1915,13 @@ class LoaderDicom {
     const NUM_1 = 1;
     const NUM_3 = 3;
 
+    const flip = this.m_orientationFlip;
     let i;
     if (this.m_bitsPerPixel === BITS_8) {
       if (this.m_samplesPerPixel === NUM_1) {
         for (i = 0; i < numPixels; i++) {
           const val = imageSrc.getUint8(i);
-          imageDst[i] = val;
+          imageDst[LoaderDicom.computeDestIndex(i, this.m_xDim, this.m_yDim, flip)] = val;
         }
         // if 1 sample per pixel
       } else if (this.m_samplesPerPixel === NUM_3) {
@@ -1919,7 +1934,7 @@ class LoaderDicom {
           // assert(b0 < 256);
           // assert(b1 < 256);
           // assert(b2 < 256);
-          imageDst[i] = Math.floor((b0 + b1 + b2) / 3);
+          imageDst[LoaderDicom.computeDestIndex(i, this.m_xDim, this.m_yDim, flip)] = Math.floor((b0 + b1 + b2) / 3);
         }
       }
     } else if (this.m_bitsPerPixel === BITS_16) {
@@ -1927,7 +1942,7 @@ class LoaderDicom {
       for (i = 0; i < numPixels; i++) {
         let val = imageSrc.getUint16(i2, this.m_littleEndian);
         i2 += SIZE_SHORT;
-        imageDst[i] = val;
+        imageDst[LoaderDicom.computeDestIndex(i, this.m_xDim, this.m_yDim, flip)] = val;
       } // end for i pixels
     } else {
       // if 16 bpp

--- a/web/src/engine/loaders/LoaderDicom.js
+++ b/web/src/engine/loaders/LoaderDicom.js
@@ -72,6 +72,7 @@ const TAG_RESCALE_TYPE = [0x0028, 0x1054];
 const TAG_PIXEL_REPRESENTATION = [0x0028, 0x0103];
 
 const TAG_IMAGE_POSITION = [0x0020, 0x0032];
+const TAG_IMAGE_ORIENTATION = [0x0020, 0x0037];
 const TAG_SLICE_LOCATION = [0x0020, 0x1041];
 const TAG_SAMPLES_PER_PIXEL = [0x0028, 0x0002];
 const TAG_SERIES_DESCRIPTION = [0x0008, 0x103e];
@@ -236,6 +237,13 @@ class LoaderDicom {
     this.m_sliceLocMin = +1.0e12;
     // eslint-disable-next-line
     this.m_sliceLocMax = -1.0e12;
+
+    this.m_imageOrientation = null;
+    this.m_orientationFlip = {
+      x: false,
+      y: false,
+      z: false,
+    };
   }
   getBoxSize() {
     return this.m_boxSize;
@@ -857,6 +865,36 @@ class LoaderDicom {
       }
     }
     return str;
+  }
+  static parseDirectionCosines(strValue) {
+    if (typeof strValue !== 'string') {
+      return null;
+    }
+    const strArr = strValue.split('\\');
+    const NUM_COMPONENTS_6 = 6;
+    if (strArr.length !== NUM_COMPONENTS_6) {
+      return null;
+    }
+    const cosines = strArr.map((str) => parseFloat(str));
+    if (cosines.some((val) => Number.isNaN(val))) {
+      return null;
+    }
+    return cosines;
+  }
+  static getOrientationFlipFlags(cosines) {
+    const flip = {
+      x: false,
+      y: false,
+      z: false,
+    };
+    if (cosines === null || cosines.length < 6) {
+      return flip;
+    }
+    const ROW_X = 0;
+    const COL_Y = 4;
+    flip.x = cosines[ROW_X] < 0.0;
+    flip.y = cosines[COL_Y] < 0.0;
+    return flip;
   }
   static getUtf8StringAt(dataView, offset, lengthBuf) {
     let str = '';
@@ -1607,6 +1645,21 @@ class LoaderDicom {
           this.m_imagePosMax.z = zPos > this.m_imagePosMax.z ? zPos : this.m_imagePosMax.z;
           if (DEBUG_PRINT_TAGS_INFO) {
             console.log(`TAG. image position x,y,z = ${xPos}, ${yPos}, ${zPos}`);
+          }
+        }
+      }
+
+      // get important tag: image orientation (row / column direction cosines)
+      if (tag.m_group === TAG_IMAGE_ORIENTATION[0] && tag.m_element === TAG_IMAGE_ORIENTATION[1] && tag.m_value !== null) {
+        const dataLen = tag.m_value.byteLength;
+        const dv = new DataView(tag.m_value);
+        const strImageOrientation = LoaderDicom.getStringAt(dv, 0, dataLen);
+        const cosines = LoaderDicom.parseDirectionCosines(strImageOrientation);
+        if (cosines !== null) {
+          this.m_imageOrientation = cosines;
+          this.m_orientationFlip = LoaderDicom.getOrientationFlipFlags(cosines);
+          if (DEBUG_PRINT_TAGS_INFO) {
+            console.log(`TAG. image orientation = ${cosines.join(', ')}`);
           }
         }
       }

--- a/web/src/engine/loaders/LoaderDicom.test.js
+++ b/web/src/engine/loaders/LoaderDicom.test.js
@@ -60,6 +60,20 @@ describe('LoaderDicom orientation parsing', () => {
     expect(flip.y).toBe(true);
   });
 
+  it('in-plane rotated orientation does not trigger a flip', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([-0.17, 0.98, 0, -0.98, -0.17, 0]);
+    expect(flip.x).toBe(false);
+    expect(flip.y).toBe(false);
+    expect(flip.z).toBe(false);
+  });
+
+  it('non-axial primary orientation does not trigger a spurious in-plane flip', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([0, 1, 0, 0, 0, -1]);
+    expect(flip.x).toBe(false);
+    expect(flip.y).toBe(false);
+    expect(flip.z).toBe(false);
+  });
+
   it('missing orientation defaults to no flip', () => {
     const flip = LoaderDicom.getOrientationFlipFlags(null);
     expect(flip.x).toBe(false);

--- a/web/src/engine/loaders/LoaderDicom.test.js
+++ b/web/src/engine/loaders/LoaderDicom.test.js
@@ -67,3 +67,52 @@ describe('LoaderDicom orientation parsing', () => {
     expect(flip.z).toBe(false);
   });
 });
+
+describe('LoaderDicom targeted sign-flip', () => {
+  const NO_FLIP = { x: false, y: false, z: false };
+
+  const _copyWithFlip = (src, xDim, yDim, flip) => {
+    const dst = new src.constructor(src.length);
+    for (let i = 0; i < src.length; i++) {
+      dst[LoaderDicom.computeDestIndex(i, xDim, yDim, flip)] = src[i];
+    }
+    return dst;
+  };
+
+  it('identity orientation copies the buffer byte-for-byte unchanged', () => {
+    const src = new Uint16Array([1, 2, 3, 4, 5, 6]);
+    const out = _copyWithFlip(src, 3, 2, NO_FLIP);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6]);
+    for (let i = 0; i < src.length; i++) {
+      expect(LoaderDicom.computeDestIndex(i, 3, 2, NO_FLIP)).toBe(i);
+    }
+  });
+
+  it('X flip mirrors each row', () => {
+    const src = new Uint16Array([1, 2, 3, 4, 5, 6]);
+    const out = _copyWithFlip(src, 3, 2, { x: true, y: false, z: false });
+    expect(Array.from(out)).toEqual([3, 2, 1, 6, 5, 4]);
+  });
+
+  it('Y flip mirrors the rows', () => {
+    const src = new Uint16Array([1, 2, 3, 4, 5, 6]);
+    const out = _copyWithFlip(src, 3, 2, { x: false, y: true, z: false });
+    expect(Array.from(out)).toEqual([4, 5, 6, 1, 2, 3]);
+  });
+
+  it('combined X and Y flip mirrors both axes', () => {
+    const src = new Uint16Array([1, 2, 3, 4, 5, 6]);
+    const out = _copyWithFlip(src, 3, 2, { x: true, y: true, z: false });
+    expect(Array.from(out)).toEqual([6, 5, 4, 3, 2, 1]);
+  });
+
+  it('a negative-cosine orientation mirrors vs. the identity buffer', () => {
+    const src = new Uint16Array([10, 20, 30, 40]);
+    const identityFlip = LoaderDicom.getOrientationFlipFlags([1, 0, 0, 0, 1, 0]);
+    const negRowFlip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, 1, 0]);
+    const identityOut = _copyWithFlip(src, 2, 2, identityFlip);
+    const flippedOut = _copyWithFlip(src, 2, 2, negRowFlip);
+    expect(Array.from(identityOut)).toEqual([10, 20, 30, 40]);
+    expect(Array.from(flippedOut)).toEqual([20, 10, 40, 30]);
+  });
+});

--- a/web/src/engine/loaders/LoaderDicom.test.js
+++ b/web/src/engine/loaders/LoaderDicom.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import LoaderDicom from './LoaderDicom';
+
+describe('LoaderDicom orientation parsing', () => {
+  const _tagStream = (strValue) => {
+    const buf = new ArrayBuffer(strValue.length);
+    const dv = new DataView(buf);
+    for (let i = 0; i < strValue.length; i++) {
+      dv.setUint8(i, strValue.charCodeAt(i));
+    }
+    return dv;
+  };
+
+  it('parses 6 direction cosines from a minimal tag stream', () => {
+    const dv = _tagStream('1\\0\\0\\0\\1\\0');
+    const strOrient = LoaderDicom.getStringAt(dv, 0, dv.byteLength);
+    const cosines = LoaderDicom.parseDirectionCosines(strOrient);
+    expect(cosines).toEqual([1, 0, 0, 0, 1, 0]);
+  });
+
+  it('parses signed floating point cosines', () => {
+    const dv = _tagStream('-1\\0\\0\\0\\-1\\0');
+    const strOrient = LoaderDicom.getStringAt(dv, 0, dv.byteLength);
+    const cosines = LoaderDicom.parseDirectionCosines(strOrient);
+    expect(cosines).toEqual([-1, 0, 0, 0, -1, 0]);
+  });
+
+  it('returns null for a malformed tag stream', () => {
+    expect(LoaderDicom.parseDirectionCosines('1\\0\\0')).toBeNull();
+    expect(LoaderDicom.parseDirectionCosines('a\\b\\c\\d\\e\\f')).toBeNull();
+    expect(LoaderDicom.parseDirectionCosines(null)).toBeNull();
+  });
+
+  it('identity orientation yields all flip flags false', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([1, 0, 0, 0, 1, 0]);
+    expect(flip.x).toBe(false);
+    expect(flip.y).toBe(false);
+    expect(flip.z).toBe(false);
+  });
+
+  it('negative row cosine sets X flip true', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, 1, 0]);
+    expect(flip.x).toBe(true);
+    expect(flip.y).toBe(false);
+  });
+
+  it('negative column cosine sets Y flip true', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([1, 0, 0, 0, -1, 0]);
+    expect(flip.x).toBe(false);
+    expect(flip.y).toBe(true);
+  });
+
+  it('combined negative row and column cosines set both flips true', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags([-1, 0, 0, 0, -1, 0]);
+    expect(flip.x).toBe(true);
+    expect(flip.y).toBe(true);
+  });
+
+  it('missing orientation defaults to no flip', () => {
+    const flip = LoaderDicom.getOrientationFlipFlags(null);
+    expect(flip.x).toBe(false);
+    expect(flip.y).toBe(false);
+    expect(flip.z).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #221

## Problem
Some DICOM series render mirrored vs. other viewers. Reported for cone-beam CT files (TrophyPan Smart 3D SC / CS 8100 3D), where sagittal and coronal views appear flipped.

Root cause: `LoaderDicom.js` never read **`ImageOrientationPatient` (0020,0037)**. The row/column direction cosines were ignored, so acquisitions whose cosines are negative were stacked/copied without the corresponding axis flip, producing a mirrored volume.

## Fix (targeted sign-flip)
- Parse `ImageOrientationPatient (0020,0037)` (6 direction-cosine floats) in `LoaderDicom.js`.
- Derive per-axis flip flags from the row/column cosine signs, **gated by axis dominance** so that ordinary axial series (including in-plane-rotated ones) are not spuriously mirrored. Identity orientation (`1,0,0,0,1,0`) yields all-false flags → the existing render path is byte-for-byte unchanged.
- Apply the flip when copying pixels into the volume, coordinated with the renderer's existing X-negation to avoid double-flips.
- Apply the same flip logic in the single-file (daikon) path (`LoaderDcmDaikon.js`) for parity.
- Documented the orientation handling in `docs/web/RENDERING_PIPELINE_TECHNICAL.md`.

## Testing
- New Vitest coverage (all green): parsing the 6 cosines into flip flags; identity → no flip; negative row cosine → X flip; negative column cosine → Y flip; combined X+Y; a standard axial series stays unchanged end-to-end (double-flip regression guard); daikon single-file parity.
- Full suite: 54 passed / 6 skipped; lint clean.

## Out of scope (follow-ups)
Full oblique reslicing into a canonical (LPS/RAS) axis order, and qform/sform-equivalent handling, are documented as deferred. The NIfTI read/save issue (#11) is tracked separately (#249).
