### PR TITLE
fix(3d): surface capability/shader/framebuffer errors instead of silent black screen (#208, #238)

### DIFF
--- a/docs/web/3D_RENDER_CAPABILITY_GUARD.md
+++ b/docs/web/3D_RENDER_CAPABILITY_GUARD.md
@@ -18,6 +18,7 @@ into `THREE.FloatType` render targets. Both need a fully-featured WebGL2 context
 |---|---|
 | **WebGL2 context** | `DataTexture3D` / `texImage3D` is WebGL2-only. WebGL1 cannot upload the volume texture. |
 | **`EXT_color_buffer_float`** | Float render targets (front/back face position buffers) require this extension to be color-renderable. |
+| **`OES_texture_float_linear`** | The float front/back-face targets are sampled with `LinearFilter` (`texture2D`) inside the ray-casting shaders; without this extension WebGL2 treats the RGBA32F textures as incomplete and samples them as black — a silent black volume. |
 | **Shaders compile & link** | The scene becomes ready only after the ray-casting materials finish async compile. |
 | **Complete framebuffer** | The offscreen render targets must report `FRAMEBUFFER_COMPLETE`. |
 
@@ -36,6 +37,7 @@ as an overlay in `Graphics3d.jsx` instead of a black canvas.
 |---|---|---|
 | `webgl2` | Context is not WebGL2 (WebGL1 fallback, or no context) | *3D rendering requires WebGL2, which is not available in this browser.* |
 | `colorBufferFloat` | WebGL2 present but `EXT_color_buffer_float` missing | *3D rendering requires float color buffer support (EXT_color_buffer_float), which is unavailable on this device.* |
+| `floatLinear` | WebGL2 + `EXT_color_buffer_float` present but `OES_texture_float_linear` missing | *3D rendering requires linear filtering of float textures (OES_texture_float_linear), which is unavailable on this device.* |
 | `shader` | Scene never reaches ready state within the timeout (shader compile/link failed) | *3D shaders failed to load.* |
 | `framebuffer` | Render target reports an incomplete framebuffer | *3D render target (framebuffer) is incomplete.* |
 | `null` (`NONE`) | Everything OK — normal render | *(no overlay)* |
@@ -48,7 +50,7 @@ The logic lives in pure, unit-tested helpers under `web/src/engine/gl/`; the
 renderer only wires them into the existing flow.
 
 - **`detect3dCapabilities.js`** — `detect3dCapabilities(gl)` inspects the live
-  context and returns `{ webgl2, colorBufferFloat, reason }`. Pure; testable with
+  context and returns `{ webgl2, colorBufferFloat, floatLinear, reason }`. Pure; testable with
   stub `gl` objects.
 - **`gate3dCapability.js`** — `decide3dCapabilityGate(caps)` turns detected
   capabilities into a decision `{ proceed, isWebGL2, error }`. The gate's

--- a/docs/web/3D_RENDER_CAPABILITY_GUARD.md
+++ b/docs/web/3D_RENDER_CAPABILITY_GUARD.md
@@ -51,9 +51,10 @@ renderer only wires them into the existing flow.
   context and returns `{ webgl2, colorBufferFloat, reason }`. Pure; testable with
   stub `gl` objects.
 - **`gate3dCapability.js`** — `decide3dCapabilityGate(caps)` turns detected
-  capabilities into a decision `{ proceed, isWebGL2, error }`. This value replaces
-  the former hardcoded `volumeFilter3d.js` `isWebGL2 = 1`, so `isWebGL2` now
-  reflects the real context.
+  capabilities into a decision `{ proceed, isWebGL2, error }`. The gate's
+  `isWebGL2` replaces `glSelector.useWebGL2()` in `VolumeRenderer3d.js`. Separately,
+  `volumeFilter3d.js`'s former hardcoded `isWebGL2 = 1` is now derived from
+  `isWebGL2Context(context)`, so both paths reflect the real context.
 - **`render3dReadyState.js`** — `evaluateReadyState(...)` detects a stuck
   `sceneReadyCounter` (async shader compile never completed) via a
   `SCENE_READY_TIMEOUT_MS` timeout and surfaces `shader`;

--- a/docs/web/3D_RENDER_CAPABILITY_GUARD.md
+++ b/docs/web/3D_RENDER_CAPABILITY_GUARD.md
@@ -1,0 +1,113 @@
+# 3D Render Capability Guard & Error States
+
+Reference for the capability guard that fronts the 3D volume renderer, the error
+states it can surface, and troubleshooting guidance for environment-specific
+black-screen reports (#208, #238).
+
+Before this guard existed, a 3D render failure produced a **silent black canvas**
+with no message. The guard turns each failure into a specific, on-screen reason.
+
+---
+
+## Requirements for 3D rendering
+
+The 3D ray-casting path uploads the volume as a `THREE.DataTexture3D` and renders
+into `THREE.FloatType` render targets. Both need a fully-featured WebGL2 context:
+
+| Requirement | Why it is needed |
+|---|---|
+| **WebGL2 context** | `DataTexture3D` / `texImage3D` is WebGL2-only. WebGL1 cannot upload the volume texture. |
+| **`EXT_color_buffer_float`** | Float render targets (front/back face position buffers) require this extension to be color-renderable. |
+| **Shaders compile & link** | The scene becomes ready only after the ray-casting materials finish async compile. |
+| **Complete framebuffer** | The offscreen render targets must report `FRAMEBUFFER_COMPLETE`. |
+
+On fully-capable WebGL2 hardware the render path behaves exactly as before — only
+the failure paths changed.
+
+---
+
+## Error states
+
+The guard resolves every failure to one of the reasons below. The reason is mapped
+to a user-facing message by `web/src/engine/gl/render3dErrorMessage.js` and shown
+as an overlay in `Graphics3d.jsx` instead of a black canvas.
+
+| Reason (`RENDER_ERROR`) | Trigger | Message shown |
+|---|---|---|
+| `webgl2` | Context is not WebGL2 (WebGL1 fallback, or no context) | *3D rendering requires WebGL2, which is not available in this browser.* |
+| `colorBufferFloat` | WebGL2 present but `EXT_color_buffer_float` missing | *3D rendering requires float color buffer support (EXT_color_buffer_float), which is unavailable on this device.* |
+| `shader` | Scene never reaches ready state within the timeout (shader compile/link failed) | *3D shaders failed to load.* |
+| `framebuffer` | Render target reports an incomplete framebuffer | *3D render target (framebuffer) is incomplete.* |
+| `null` (`NONE`) | Everything OK — normal render | *(no overlay)* |
+
+---
+
+## How the guard is wired
+
+The logic lives in pure, unit-tested helpers under `web/src/engine/gl/`; the
+renderer only wires them into the existing flow.
+
+- **`detect3dCapabilities.js`** — `detect3dCapabilities(gl)` inspects the live
+  context and returns `{ webgl2, colorBufferFloat, reason }`. Pure; testable with
+  stub `gl` objects.
+- **`gate3dCapability.js`** — `decide3dCapabilityGate(caps)` turns detected
+  capabilities into a decision `{ proceed, isWebGL2, error }`. This value replaces
+  the former hardcoded `volumeFilter3d.js` `isWebGL2 = 1`, so `isWebGL2` now
+  reflects the real context.
+- **`render3dReadyState.js`** — `evaluateReadyState(...)` detects a stuck
+  `sceneReadyCounter` (async shader compile never completed) via a
+  `SCENE_READY_TIMEOUT_MS` timeout and surfaces `shader`;
+  `mapFramebufferStatus(status, FRAMEBUFFER_COMPLETE)` re-enables a real
+  framebuffer completeness check (previously stubbed to `CHECK_MODE_RESULT_OK`).
+- **`render3dErrorMessage.js`** — `render3dErrorMessage(reason)` maps a reason to
+  the user-facing string (or `null` when there is no error).
+
+Integration points:
+
+- `VolumeRenderer3d.js` computes `decide3dCapabilityGate(...)` at init, sets
+  `renderErrorReason` when the gate fails, on the missing-`EXT_color_buffer_float`
+  branch, and from the ready-state / framebuffer checks in `render()`.
+- `Graphics3d.jsx` reads `getRenderErrorReason()` each render, maps it with
+  `render3dErrorMessage(...)`, and shows the overlay when a message is present.
+
+---
+
+## Troubleshooting
+
+### "3D rendering requires WebGL2" / "float color buffer unavailable"
+The device or browser genuinely lacks the capability. Confirm via
+`about:gpu` / a WebGL report; software renderers and older mobile GPUs frequently
+lack `EXT_color_buffer_float`. This is a hardware/driver limitation, not a bug.
+
+### "3D shaders failed to load" (env-specific black screen — #238)
+This is the most likely signal behind **#238**, where 3D works on **Prod** but
+shows black on **Dev/Tst**. The capability is present, yet the scene never becomes
+ready — the ray-casting shader chunks did not compile or load.
+
+Working hypothesis: a **deploy / CDN / asset-loading difference** between
+environments (e.g. shader chunks served from a different base path, blocked by CSP,
+or 404/MIME-mismatched by the CDN) — **not reproducible from this repo alone**.
+
+When the `shader` error appears in a given environment, check:
+- Network tab for failed/`404`/wrong-MIME shader or chunk requests.
+- The asset base path / `publicPath` used by that environment's build vs Prod.
+- CSP or CDN rewrite rules that could block or alter shader chunk delivery.
+- The browser console for WebGL shader compile/link errors.
+
+The surfaced `shader` error is precisely the diagnostic that makes this failure
+visible in the affected environment instead of a silent black frame.
+
+### "3D render target (framebuffer) is incomplete"
+The float render targets could not be allocated as complete framebuffers even
+though the extension reported available — typically a driver/size limitation.
+Reproduce with a smaller volume and check console for GL errors.
+
+---
+
+## Related
+
+- Issues: **#208** (silent black 3D in a production build — capability guard),
+  **#238** (env-specific black 3D on Dev/Tst — diagnosable via the `shader` error).
+- Empty-volume black-3D caused by `ERROR_COMPRESSED_IMAGE_NOT_SUPPORTED` is a
+  **separate** loader-side cause tracked in the compressed-DICOM plan.
+- Plan: `docs/plans/20260807-3d-render-capability-guard.md`.

--- a/web/src/engine/Graphics3d.jsx
+++ b/web/src/engine/Graphics3d.jsx
@@ -9,6 +9,7 @@ import ViewMode from '../store/ViewMode';
 import Modes3d from '../store/Modes3d';
 import StoreActionType from '../store/ActionTypes';
 import VolumeRenderer3d from './VolumeRenderer3d';
+import { render3dErrorMessage } from './gl/render3dErrorMessage';
 //import DistanceTool from '../tools23d/distancetool'
 
 class Graphics3d extends React.Component {
@@ -48,6 +49,7 @@ class Graphics3d extends React.Component {
     this.state = {
       wRender: 0,
       hRender: 0,
+      renderError: null,
     };
   }
 
@@ -168,6 +170,12 @@ class Graphics3d extends React.Component {
       //  return;
       //}
       this.isLoaded = true;
+    }
+    if (this.m_volumeRenderer3D !== null && typeof this.m_volumeRenderer3D.getRenderErrorReason === 'function') {
+      const reason = this.m_volumeRenderer3D.getRenderErrorReason();
+      if (reason) {
+        this.setState({ renderError: reason });
+      }
     }
     this.start();
     // setup keyboard
@@ -361,6 +369,27 @@ class Graphics3d extends React.Component {
       width: '100%',
       height: '100%',
       display: 'block',
+      position: 'relative',
+    };
+
+    let renderErrorReason = this.state.renderError;
+    if (this.m_volumeRenderer3D !== null && typeof this.m_volumeRenderer3D.getRenderErrorReason === 'function') {
+      renderErrorReason = this.m_volumeRenderer3D.getRenderErrorReason() || renderErrorReason;
+    }
+    const errorMessage = render3dErrorMessage(renderErrorReason);
+
+    const errorStyleObj = {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      maxWidth: '80%',
+      padding: '12px 16px',
+      textAlign: 'center',
+      color: '#fff',
+      background: 'rgba(150, 0, 0, 0.85)',
+      borderRadius: '4px',
+      pointerEvents: 'none',
     };
 
     return (
@@ -382,7 +411,13 @@ class Graphics3d extends React.Component {
         onKeyDown={(evt) => this.onKeyDown(evt)}
         onKeyUp={(evt) => this.onKeyUp(evt)}
         onWheel={this._onWheel.bind(this)}
-      />
+      >
+        {errorMessage !== null ? (
+          <div style={errorStyleObj} role="alert" data-testid="graphics3d-render-error">
+            {errorMessage}
+          </div>
+        ) : null}
+      </div>
     );
   }
 }

--- a/web/src/engine/Graphics3d.jsx
+++ b/web/src/engine/Graphics3d.jsx
@@ -23,6 +23,7 @@ class Graphics3d extends React.Component {
     this.stop = this.stop.bind(this);
     this.animate = this.animate.bind(this);
     this.renderScene = this.renderScene.bind(this);
+    this.syncRenderError = this.syncRenderError.bind(this);
     this.setVolRenderToStore = this.setVolRenderToStore.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyUp = this.onKeyUp.bind(this);
@@ -90,7 +91,17 @@ class Graphics3d extends React.Component {
     this.m_material.wireframe = (this.m_mode3d === Modes3d.ISO);*/
 
     this.renderScene();
+    this.syncRenderError();
     this.m_frameId = window.requestAnimationFrame(this.animate);
+  }
+
+  syncRenderError() {
+    if (this.m_volumeRenderer3D !== null && typeof this.m_volumeRenderer3D.getRenderErrorReason === 'function') {
+      const reason = this.m_volumeRenderer3D.getRenderErrorReason() || null;
+      if (reason !== this.state.renderError) {
+        this.setState({ renderError: reason });
+      }
+    }
   }
 
   renderScene() {

--- a/web/src/engine/VolumeRenderer3d.js
+++ b/web/src/engine/VolumeRenderer3d.js
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import GlSelector from './GlSelector';
 import { detect3dCapabilities } from './gl/detect3dCapabilities';
 import { decide3dCapabilityGate, RENDER_ERROR } from './gl/gate3dCapability';
+import { evaluateReadyState, mapFramebufferStatus, SCENE_READY_TIMEOUT_MS } from './gl/render3dReadyState';
 import OrbitControl from './orbitcontrol';
 import MaterialBF from './gfx/matbackface';
 import MaterialFF from './gfx/matfrontface';
@@ -46,6 +47,7 @@ const OPACITY_SCALE = 175.0;
 // Special values to check frame buffer
 const CHECK_MODE_NOT_CHECKED = 0;
 const CHECK_MODE_RESULT_OK = 1;
+const CHECK_MODE_RESULT_FAIL = 2;
 
 // When scene is ready (how much materials are created via arrow functions)
 const SCENE_READY_COUNTER_OK = 5;
@@ -65,6 +67,7 @@ export default class VolumeRenderer3d {
   constructor(props) {
     this.curFileDataType = props.curFileDataType;
     this.sceneReadyCounter = 0;
+    this.sceneReadyStartTime = null;
     this.renderCounter = 0;
     this.scene = new THREE.Scene();
     this.sceneClipPlane = new THREE.Scene();
@@ -846,6 +849,7 @@ export default class VolumeRenderer3d {
 
     this.renderScene = SCENE_TYPE_RAYCAST;
     this.sceneReadyCounter = 0;
+    this.sceneReadyStartTime = Date.now();
     this.renderCounter = 0;
     let matBfThreeGS = null;
     let matFfThreeGS = null;
@@ -1268,6 +1272,43 @@ export default class VolumeRenderer3d {
     return true;
   }
 
+  /** Evaluate a stuck ready-state and surface a shader error instead of a permanent silent black screen */
+  evaluateReadyTimeout() {
+    if (this.renderErrorReason) {
+      return;
+    }
+    const elapsedMs = this.sceneReadyStartTime === null ? 0 : Date.now() - this.sceneReadyStartTime;
+    const state = evaluateReadyState({
+      readyCounter: this.sceneReadyCounter,
+      expectedCounter: SCENE_READY_COUNTER_OK,
+      materialsReady: this.matVolumeRender !== null && this.matBF !== null && this.matFF !== null && this.matRenderToTexture !== null,
+      elapsedMs,
+      timeoutMs: SCENE_READY_TIMEOUT_MS,
+    });
+    if (state.timedOut) {
+      this.renderErrorReason = state.error;
+      console.log('3D scene not ready after timeout (shaders failed to load)');
+    }
+  }
+
+  /** Run a real framebuffer completeness check on the back-face render target */
+  runFrameBufferCheck() {
+    const gl = this.renderer && typeof this.renderer.getContext === 'function' ? this.renderer.getContext() : null;
+    if (!gl || typeof gl.checkFramebufferStatus !== 'function') {
+      return CHECK_MODE_RESULT_OK;
+    }
+    this.renderer.setRenderTarget(this.bfTexture);
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    this.renderer.setRenderTarget(null);
+    const result = mapFramebufferStatus(status, gl.FRAMEBUFFER_COMPLETE);
+    if (!result.ok) {
+      this.renderErrorReason = this.renderErrorReason || result.error;
+      console.log(`3D framebuffer incomplete (status=${status})`);
+      return CHECK_MODE_RESULT_FAIL;
+    }
+    return CHECK_MODE_RESULT_OK;
+  }
+
   /** Render 3d scene */
   render() {
     /*if (this.sceneReadyCounter !== SCENE_READY_COUNTER_OK) {
@@ -1276,6 +1317,7 @@ export default class VolumeRenderer3d {
       return;
     }*/
     if (!this.isReadyToRender()) {
+      this.evaluateReadyTimeout();
       return;
     }
     const matReady = this.matVolumeRender !== null && this.matBF !== null && this.matFF !== null && this.matRenderToTexture !== null;
@@ -1284,8 +1326,10 @@ export default class VolumeRenderer3d {
     } else {
       // check once render target
       if (this.checkFrameBufferMode === CHECK_MODE_NOT_CHECKED) {
-        // const isGood = true;// GlCheck.checkFrameBuffer(this.renderer, this.bfTexture);
-        this.checkFrameBufferMode = CHECK_MODE_RESULT_OK;
+        this.checkFrameBufferMode = this.runFrameBufferCheck();
+      }
+      if (this.checkFrameBufferMode === CHECK_MODE_RESULT_FAIL) {
+        return;
       }
 
       if (this.renderScene === SCENE_TYPE_RAYCAST) {

--- a/web/src/engine/VolumeRenderer3d.js
+++ b/web/src/engine/VolumeRenderer3d.js
@@ -850,6 +850,8 @@ export default class VolumeRenderer3d {
     this.renderScene = SCENE_TYPE_RAYCAST;
     this.sceneReadyCounter = 0;
     this.sceneReadyStartTime = Date.now();
+    this.renderErrorReason = null;
+    this.checkFrameBufferMode = CHECK_MODE_NOT_CHECKED;
     this.renderCounter = 0;
     let matBfThreeGS = null;
     let matFfThreeGS = null;
@@ -1319,6 +1321,9 @@ export default class VolumeRenderer3d {
     if (!this.isReadyToRender()) {
       this.evaluateReadyTimeout();
       return;
+    }
+    if (this.renderErrorReason === RENDER_ERROR.SHADER) {
+      this.renderErrorReason = null;
     }
     const matReady = this.matVolumeRender !== null && this.matBF !== null && this.matFF !== null && this.matRenderToTexture !== null;
     if (!matReady) {

--- a/web/src/engine/VolumeRenderer3d.js
+++ b/web/src/engine/VolumeRenderer3d.js
@@ -982,6 +982,7 @@ export default class VolumeRenderer3d {
     } else {
       console.log('cant create float texture');
       this.renderErrorReason = RENDER_ERROR.COLOR_BUFFER_FLOAT;
+      return;
     }
 
     this.createClipPlaneGeometry();

--- a/web/src/engine/VolumeRenderer3d.js
+++ b/web/src/engine/VolumeRenderer3d.js
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 
 import GlSelector from './GlSelector';
 import { detect3dCapabilities } from './gl/detect3dCapabilities';
-import { decide3dCapabilityGate } from './gl/gate3dCapability';
+import { decide3dCapabilityGate, RENDER_ERROR } from './gl/gate3dCapability';
 import OrbitControl from './orbitcontrol';
 import MaterialBF from './gfx/matbackface';
 import MaterialFF from './gfx/matfrontface';
@@ -975,6 +975,7 @@ export default class VolumeRenderer3d {
       this.bufferRenderToTextureCPU = new Float32Array(VAL_4 * this.xSmallTexSize * this.ySmallTexSize);
     } else {
       console.log('cant create float texture');
+      this.renderErrorReason = RENDER_ERROR.COLOR_BUFFER_FLOAT;
     }
 
     this.createClipPlaneGeometry();

--- a/web/src/engine/VolumeRenderer3d.js
+++ b/web/src/engine/VolumeRenderer3d.js
@@ -5,6 +5,8 @@
 import * as THREE from 'three';
 
 import GlSelector from './GlSelector';
+import { detect3dCapabilities } from './gl/detect3dCapabilities';
+import { decide3dCapabilityGate } from './gl/gate3dCapability';
 import OrbitControl from './orbitcontrol';
 import MaterialBF from './gfx/matbackface';
 import MaterialFF from './gfx/matfrontface';
@@ -114,7 +116,10 @@ export default class VolumeRenderer3d {
     // this.canvas3d = document.createElementNS('http://www.w3.org/1999/xhtml', 'canvas');
     const glSelector = new GlSelector();
     this.context = glSelector.createWebGLContext();
-    this.isWebGL2 = glSelector.useWebGL2();
+    this.capabilities = detect3dCapabilities(this.context);
+    this.capabilityGate = decide3dCapabilityGate(this.capabilities);
+    this.isWebGL2 = this.capabilityGate.isWebGL2;
+    this.renderErrorReason = this.capabilityGate.error;
     this.canvas3d = glSelector.getCanvas();
     this.renderer = new THREE.WebGLRenderer({
       antialias: false,
@@ -801,7 +806,16 @@ export default class VolumeRenderer3d {
    * @param (object) nonEmptyBoxMin - Min corner for non empty box in volume
    * @param (bool) isRoiVolume) - is roi volume
    */
+  getRenderErrorReason() {
+    return this.renderErrorReason;
+  }
+
   initWithVolume(volume, box, nonEmptyBoxMin, nonEmptyBoxMax, isRoiVolume, isFULL3D) {
+    if (!this.capabilityGate || !this.capabilityGate.proceed) {
+      this.renderErrorReason = this.capabilityGate ? this.capabilityGate.error : decide3dCapabilityGate(null).error;
+      console.log(`3D render blocked: missing capability (${this.renderErrorReason})`);
+      return;
+    }
     let sideMax = box.x > box.y ? box.x : box.y;
     sideMax = box.z > sideMax ? box.z : sideMax;
     this.vBoxVirt.x = box.x / sideMax;

--- a/web/src/engine/gl/detect3dCapabilities.js
+++ b/web/src/engine/gl/detect3dCapabilities.js
@@ -2,6 +2,7 @@ export const CAP_REASON = {
   OK: null,
   WEBGL2: 'webgl2',
   COLOR_BUFFER_FLOAT: 'colorBufferFloat',
+  FLOAT_LINEAR: 'floatLinear',
 };
 
 export function isWebGL2Context(gl) {
@@ -21,14 +22,25 @@ export function hasColorBufferFloat(gl) {
   return gl.getExtension('EXT_color_buffer_float') != null;
 }
 
+export function hasFloatLinear(gl) {
+  if (!gl || typeof gl.getExtension !== 'function') {
+    return false;
+  }
+  return gl.getExtension('OES_texture_float_linear') != null;
+}
+
 export function detect3dCapabilities(gl) {
   const webgl2 = isWebGL2Context(gl);
   if (!webgl2) {
-    return { webgl2: false, colorBufferFloat: false, reason: CAP_REASON.WEBGL2 };
+    return { webgl2: false, colorBufferFloat: false, floatLinear: false, reason: CAP_REASON.WEBGL2 };
   }
   const colorBufferFloat = hasColorBufferFloat(gl);
   if (!colorBufferFloat) {
-    return { webgl2: true, colorBufferFloat: false, reason: CAP_REASON.COLOR_BUFFER_FLOAT };
+    return { webgl2: true, colorBufferFloat: false, floatLinear: false, reason: CAP_REASON.COLOR_BUFFER_FLOAT };
   }
-  return { webgl2: true, colorBufferFloat: true, reason: CAP_REASON.OK };
+  const floatLinear = hasFloatLinear(gl);
+  if (!floatLinear) {
+    return { webgl2: true, colorBufferFloat: true, floatLinear: false, reason: CAP_REASON.FLOAT_LINEAR };
+  }
+  return { webgl2: true, colorBufferFloat: true, floatLinear: true, reason: CAP_REASON.OK };
 }

--- a/web/src/engine/gl/detect3dCapabilities.js
+++ b/web/src/engine/gl/detect3dCapabilities.js
@@ -1,0 +1,34 @@
+export const CAP_REASON = {
+  OK: null,
+  WEBGL2: 'webgl2',
+  COLOR_BUFFER_FLOAT: 'colorBufferFloat',
+};
+
+export function isWebGL2Context(gl) {
+  if (!gl) {
+    return false;
+  }
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return true;
+  }
+  return typeof gl.texImage3D === 'function';
+}
+
+export function hasColorBufferFloat(gl) {
+  if (!gl || typeof gl.getExtension !== 'function') {
+    return false;
+  }
+  return gl.getExtension('EXT_color_buffer_float') != null;
+}
+
+export function detect3dCapabilities(gl) {
+  const webgl2 = isWebGL2Context(gl);
+  if (!webgl2) {
+    return { webgl2: false, colorBufferFloat: false, reason: CAP_REASON.WEBGL2 };
+  }
+  const colorBufferFloat = hasColorBufferFloat(gl);
+  if (!colorBufferFloat) {
+    return { webgl2: true, colorBufferFloat: false, reason: CAP_REASON.COLOR_BUFFER_FLOAT };
+  }
+  return { webgl2: true, colorBufferFloat: true, reason: CAP_REASON.OK };
+}

--- a/web/src/engine/gl/detect3dCapabilities.test.js
+++ b/web/src/engine/gl/detect3dCapabilities.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { detect3dCapabilities, isWebGL2Context, hasColorBufferFloat, CAP_REASON } from './detect3dCapabilities';
+
+function makeWebGL2(extPresent) {
+  return {
+    texImage3D() {},
+    getExtension(name) {
+      if (name === 'EXT_color_buffer_float' && extPresent) {
+        return {};
+      }
+      return null;
+    },
+  };
+}
+
+function makeWebGL1() {
+  return {
+    getExtension() {
+      return null;
+    },
+  };
+}
+
+describe('detect3dCapabilities', () => {
+  it('reports ok for WebGL2 with EXT_color_buffer_float', () => {
+    const caps = detect3dCapabilities(makeWebGL2(true));
+    expect(caps).toEqual({ webgl2: true, colorBufferFloat: true, reason: CAP_REASON.OK });
+  });
+
+  it('reports webgl2 reason for a WebGL1 context', () => {
+    const caps = detect3dCapabilities(makeWebGL1());
+    expect(caps.webgl2).toBe(false);
+    expect(caps.colorBufferFloat).toBe(false);
+    expect(caps.reason).toBe('webgl2');
+  });
+
+  it('reports colorBufferFloat reason for WebGL2 without the extension', () => {
+    const caps = detect3dCapabilities(makeWebGL2(false));
+    expect(caps.webgl2).toBe(true);
+    expect(caps.colorBufferFloat).toBe(false);
+    expect(caps.reason).toBe('colorBufferFloat');
+  });
+
+  it('treats a null context as no capability', () => {
+    const caps = detect3dCapabilities(null);
+    expect(caps.webgl2).toBe(false);
+    expect(caps.reason).toBe('webgl2');
+  });
+
+  it('isWebGL2Context detects the WebGL2-only texImage3D method', () => {
+    expect(isWebGL2Context(makeWebGL2(true))).toBe(true);
+    expect(isWebGL2Context(makeWebGL1())).toBe(false);
+    expect(isWebGL2Context(null)).toBe(false);
+  });
+
+  it('hasColorBufferFloat reflects the extension presence', () => {
+    expect(hasColorBufferFloat(makeWebGL2(true))).toBe(true);
+    expect(hasColorBufferFloat(makeWebGL2(false))).toBe(false);
+    expect(hasColorBufferFloat(null)).toBe(false);
+  });
+});

--- a/web/src/engine/gl/detect3dCapabilities.test.js
+++ b/web/src/engine/gl/detect3dCapabilities.test.js
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { detect3dCapabilities, isWebGL2Context, hasColorBufferFloat, CAP_REASON } from './detect3dCapabilities';
+import { detect3dCapabilities, isWebGL2Context, hasColorBufferFloat, hasFloatLinear, CAP_REASON } from './detect3dCapabilities';
 
-function makeWebGL2(extPresent) {
+function makeWebGL2(extPresent, floatLinearPresent = extPresent) {
   return {
     texImage3D() {},
     getExtension(name) {
       if (name === 'EXT_color_buffer_float' && extPresent) {
+        return {};
+      }
+      if (name === 'OES_texture_float_linear' && floatLinearPresent) {
         return {};
       }
       return null;
@@ -22,9 +25,17 @@ function makeWebGL1() {
 }
 
 describe('detect3dCapabilities', () => {
-  it('reports ok for WebGL2 with EXT_color_buffer_float', () => {
+  it('reports ok for WebGL2 with EXT_color_buffer_float and OES_texture_float_linear', () => {
     const caps = detect3dCapabilities(makeWebGL2(true));
-    expect(caps).toEqual({ webgl2: true, colorBufferFloat: true, reason: CAP_REASON.OK });
+    expect(caps).toEqual({ webgl2: true, colorBufferFloat: true, floatLinear: true, reason: CAP_REASON.OK });
+  });
+
+  it('reports floatLinear reason for WebGL2 with color buffer float but no float-linear filtering', () => {
+    const caps = detect3dCapabilities(makeWebGL2(true, false));
+    expect(caps.webgl2).toBe(true);
+    expect(caps.colorBufferFloat).toBe(true);
+    expect(caps.floatLinear).toBe(false);
+    expect(caps.reason).toBe('floatLinear');
   });
 
   it('reports webgl2 reason for a WebGL1 context', () => {
@@ -57,5 +68,11 @@ describe('detect3dCapabilities', () => {
     expect(hasColorBufferFloat(makeWebGL2(true))).toBe(true);
     expect(hasColorBufferFloat(makeWebGL2(false))).toBe(false);
     expect(hasColorBufferFloat(null)).toBe(false);
+  });
+
+  it('hasFloatLinear reflects the extension presence', () => {
+    expect(hasFloatLinear(makeWebGL2(true, true))).toBe(true);
+    expect(hasFloatLinear(makeWebGL2(true, false))).toBe(false);
+    expect(hasFloatLinear(null)).toBe(false);
   });
 });

--- a/web/src/engine/gl/gate3dCapability.js
+++ b/web/src/engine/gl/gate3dCapability.js
@@ -4,6 +4,7 @@ export const RENDER_ERROR = {
   NONE: CAP_REASON.OK,
   WEBGL2: CAP_REASON.WEBGL2,
   COLOR_BUFFER_FLOAT: CAP_REASON.COLOR_BUFFER_FLOAT,
+  SHADER: 'shader',
 };
 
 export function decide3dCapabilityGate(caps) {

--- a/web/src/engine/gl/gate3dCapability.js
+++ b/web/src/engine/gl/gate3dCapability.js
@@ -1,0 +1,21 @@
+import { detect3dCapabilities, CAP_REASON } from './detect3dCapabilities';
+
+export const RENDER_ERROR = {
+  NONE: CAP_REASON.OK,
+  WEBGL2: CAP_REASON.WEBGL2,
+  COLOR_BUFFER_FLOAT: CAP_REASON.COLOR_BUFFER_FLOAT,
+};
+
+export function decide3dCapabilityGate(caps) {
+  if (!caps || caps.webgl2 !== true) {
+    return { proceed: false, isWebGL2: 0, error: RENDER_ERROR.WEBGL2 };
+  }
+  if (caps.colorBufferFloat !== true) {
+    return { proceed: false, isWebGL2: 1, error: RENDER_ERROR.COLOR_BUFFER_FLOAT };
+  }
+  return { proceed: true, isWebGL2: 1, error: RENDER_ERROR.NONE };
+}
+
+export function gate3dCapabilityFromGl(gl) {
+  return decide3dCapabilityGate(detect3dCapabilities(gl));
+}

--- a/web/src/engine/gl/gate3dCapability.js
+++ b/web/src/engine/gl/gate3dCapability.js
@@ -4,6 +4,7 @@ export const RENDER_ERROR = {
   NONE: CAP_REASON.OK,
   WEBGL2: CAP_REASON.WEBGL2,
   COLOR_BUFFER_FLOAT: CAP_REASON.COLOR_BUFFER_FLOAT,
+  FLOAT_LINEAR: CAP_REASON.FLOAT_LINEAR,
   SHADER: 'shader',
   FRAMEBUFFER: 'framebuffer',
 };
@@ -14,6 +15,9 @@ export function decide3dCapabilityGate(caps) {
   }
   if (caps.colorBufferFloat !== true) {
     return { proceed: false, isWebGL2: 1, error: RENDER_ERROR.COLOR_BUFFER_FLOAT };
+  }
+  if (caps.floatLinear !== true) {
+    return { proceed: false, isWebGL2: 1, error: RENDER_ERROR.FLOAT_LINEAR };
   }
   return { proceed: true, isWebGL2: 1, error: RENDER_ERROR.NONE };
 }

--- a/web/src/engine/gl/gate3dCapability.js
+++ b/web/src/engine/gl/gate3dCapability.js
@@ -5,6 +5,7 @@ export const RENDER_ERROR = {
   WEBGL2: CAP_REASON.WEBGL2,
   COLOR_BUFFER_FLOAT: CAP_REASON.COLOR_BUFFER_FLOAT,
   SHADER: 'shader',
+  FRAMEBUFFER: 'framebuffer',
 };
 
 export function decide3dCapabilityGate(caps) {

--- a/web/src/engine/gl/gate3dCapability.test.js
+++ b/web/src/engine/gl/gate3dCapability.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { decide3dCapabilityGate, gate3dCapabilityFromGl, RENDER_ERROR } from './gate3dCapability';
+
+function makeWebGL2(extPresent) {
+  return {
+    texImage3D() {},
+    getExtension(name) {
+      if (name === 'EXT_color_buffer_float' && extPresent) {
+        return {};
+      }
+      return null;
+    },
+  };
+}
+
+function makeWebGL1() {
+  return {
+    getExtension() {
+      return null;
+    },
+  };
+}
+
+describe('decide3dCapabilityGate', () => {
+  it('proceeds on full WebGL2 + float color buffer capability', () => {
+    const gate = decide3dCapabilityGate({ webgl2: true, colorBufferFloat: true, reason: RENDER_ERROR.NONE });
+    expect(gate).toEqual({ proceed: true, isWebGL2: 1, error: RENDER_ERROR.NONE });
+  });
+
+  it('blocks and reports webgl2 when the context is not WebGL2', () => {
+    const gate = decide3dCapabilityGate({ webgl2: false, colorBufferFloat: false, reason: RENDER_ERROR.WEBGL2 });
+    expect(gate.proceed).toBe(false);
+    expect(gate.isWebGL2).toBe(0);
+    expect(gate.error).toBe(RENDER_ERROR.WEBGL2);
+  });
+
+  it('blocks and reports colorBufferFloat when the float extension is missing', () => {
+    const gate = decide3dCapabilityGate({ webgl2: true, colorBufferFloat: false, reason: RENDER_ERROR.COLOR_BUFFER_FLOAT });
+    expect(gate.proceed).toBe(false);
+    expect(gate.isWebGL2).toBe(1);
+    expect(gate.error).toBe(RENDER_ERROR.COLOR_BUFFER_FLOAT);
+  });
+
+  it('blocks a null/undefined capability object', () => {
+    expect(decide3dCapabilityGate(null).proceed).toBe(false);
+    expect(decide3dCapabilityGate(null).error).toBe(RENDER_ERROR.WEBGL2);
+    expect(decide3dCapabilityGate(undefined).proceed).toBe(false);
+  });
+});
+
+describe('gate3dCapabilityFromGl', () => {
+  it('proceeds for a capable WebGL2 context', () => {
+    expect(gate3dCapabilityFromGl(makeWebGL2(true))).toEqual({ proceed: true, isWebGL2: 1, error: RENDER_ERROR.NONE });
+  });
+
+  it('blocks a WebGL1 context', () => {
+    const gate = gate3dCapabilityFromGl(makeWebGL1());
+    expect(gate.proceed).toBe(false);
+    expect(gate.error).toBe(RENDER_ERROR.WEBGL2);
+  });
+
+  it('blocks a WebGL2 context lacking EXT_color_buffer_float', () => {
+    const gate = gate3dCapabilityFromGl(makeWebGL2(false));
+    expect(gate.proceed).toBe(false);
+    expect(gate.error).toBe(RENDER_ERROR.COLOR_BUFFER_FLOAT);
+  });
+
+  it('blocks a null context', () => {
+    expect(gate3dCapabilityFromGl(null).proceed).toBe(false);
+  });
+});

--- a/web/src/engine/gl/gate3dCapability.test.js
+++ b/web/src/engine/gl/gate3dCapability.test.js
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { decide3dCapabilityGate, gate3dCapabilityFromGl, RENDER_ERROR } from './gate3dCapability';
 
-function makeWebGL2(extPresent) {
+function makeWebGL2(extPresent, floatLinearPresent = extPresent) {
   return {
     texImage3D() {},
     getExtension(name) {
       if (name === 'EXT_color_buffer_float' && extPresent) {
+        return {};
+      }
+      if (name === 'OES_texture_float_linear' && floatLinearPresent) {
         return {};
       }
       return null;
@@ -22,9 +25,21 @@ function makeWebGL1() {
 }
 
 describe('decide3dCapabilityGate', () => {
-  it('proceeds on full WebGL2 + float color buffer capability', () => {
-    const gate = decide3dCapabilityGate({ webgl2: true, colorBufferFloat: true, reason: RENDER_ERROR.NONE });
+  it('proceeds on full WebGL2 + float color buffer + float-linear capability', () => {
+    const gate = decide3dCapabilityGate({ webgl2: true, colorBufferFloat: true, floatLinear: true, reason: RENDER_ERROR.NONE });
     expect(gate).toEqual({ proceed: true, isWebGL2: 1, error: RENDER_ERROR.NONE });
+  });
+
+  it('blocks and reports floatLinear when float-linear filtering is missing', () => {
+    const gate = decide3dCapabilityGate({
+      webgl2: true,
+      colorBufferFloat: true,
+      floatLinear: false,
+      reason: RENDER_ERROR.FLOAT_LINEAR,
+    });
+    expect(gate.proceed).toBe(false);
+    expect(gate.isWebGL2).toBe(1);
+    expect(gate.error).toBe(RENDER_ERROR.FLOAT_LINEAR);
   });
 
   it('blocks and reports webgl2 when the context is not WebGL2', () => {
@@ -63,6 +78,12 @@ describe('gate3dCapabilityFromGl', () => {
     const gate = gate3dCapabilityFromGl(makeWebGL2(false));
     expect(gate.proceed).toBe(false);
     expect(gate.error).toBe(RENDER_ERROR.COLOR_BUFFER_FLOAT);
+  });
+
+  it('blocks a WebGL2 context lacking OES_texture_float_linear', () => {
+    const gate = gate3dCapabilityFromGl(makeWebGL2(true, false));
+    expect(gate.proceed).toBe(false);
+    expect(gate.error).toBe(RENDER_ERROR.FLOAT_LINEAR);
   });
 
   it('blocks a null context', () => {

--- a/web/src/engine/gl/render3dErrorMessage.js
+++ b/web/src/engine/gl/render3dErrorMessage.js
@@ -5,6 +5,7 @@ export const RENDER_ERROR_MESSAGE = {
   [RENDER_ERROR.COLOR_BUFFER_FLOAT]:
     '3D rendering requires float color buffer support (EXT_color_buffer_float), which is unavailable on this device.',
   [RENDER_ERROR.SHADER]: '3D shaders failed to load.',
+  [RENDER_ERROR.FRAMEBUFFER]: '3D render target (framebuffer) is incomplete.',
 };
 
 export function render3dErrorMessage(reason) {

--- a/web/src/engine/gl/render3dErrorMessage.js
+++ b/web/src/engine/gl/render3dErrorMessage.js
@@ -1,0 +1,15 @@
+import { RENDER_ERROR } from './gate3dCapability';
+
+export const RENDER_ERROR_MESSAGE = {
+  [RENDER_ERROR.WEBGL2]: '3D rendering requires WebGL2, which is not available in this browser.',
+  [RENDER_ERROR.COLOR_BUFFER_FLOAT]:
+    '3D rendering requires float color buffer support (EXT_color_buffer_float), which is unavailable on this device.',
+  [RENDER_ERROR.SHADER]: '3D shaders failed to load.',
+};
+
+export function render3dErrorMessage(reason) {
+  if (!reason) {
+    return null;
+  }
+  return RENDER_ERROR_MESSAGE[reason] || `3D rendering is unavailable (${reason}).`;
+}

--- a/web/src/engine/gl/render3dErrorMessage.js
+++ b/web/src/engine/gl/render3dErrorMessage.js
@@ -4,6 +4,8 @@ export const RENDER_ERROR_MESSAGE = {
   [RENDER_ERROR.WEBGL2]: '3D rendering requires WebGL2, which is not available in this browser.',
   [RENDER_ERROR.COLOR_BUFFER_FLOAT]:
     '3D rendering requires float color buffer support (EXT_color_buffer_float), which is unavailable on this device.',
+  [RENDER_ERROR.FLOAT_LINEAR]:
+    '3D rendering requires linear filtering of float textures (OES_texture_float_linear), which is unavailable on this device.',
   [RENDER_ERROR.SHADER]: '3D shaders failed to load.',
   [RENDER_ERROR.FRAMEBUFFER]: '3D render target (framebuffer) is incomplete.',
 };

--- a/web/src/engine/gl/render3dErrorMessage.test.js
+++ b/web/src/engine/gl/render3dErrorMessage.test.js
@@ -17,8 +17,12 @@ describe('render3dErrorMessage', () => {
     expect(render3dErrorMessage(RENDER_ERROR.COLOR_BUFFER_FLOAT)).toMatch(/float color buffer/i);
   });
 
-  it('maps the shader reason to a shader-failure message', () => {
-    expect(render3dErrorMessage(RENDER_ERROR.SHADER)).toMatch(/shader/i);
+  it('maps the shader reason to the exact shader-failure message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.SHADER)).toBe('3D shaders failed to load.');
+  });
+
+  it('maps the framebuffer reason to the exact framebuffer message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.FRAMEBUFFER)).toBe('3D render target (framebuffer) is incomplete.');
   });
 
   it('falls back to a generic message for an unknown reason', () => {

--- a/web/src/engine/gl/render3dErrorMessage.test.js
+++ b/web/src/engine/gl/render3dErrorMessage.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render3dErrorMessage } from './render3dErrorMessage';
+import { RENDER_ERROR } from './gate3dCapability';
+
+describe('render3dErrorMessage', () => {
+  it('returns null when there is no error (NONE / null / undefined)', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.NONE)).toBeNull();
+    expect(render3dErrorMessage(null)).toBeNull();
+    expect(render3dErrorMessage(undefined)).toBeNull();
+  });
+
+  it('maps the webgl2 reason to a WebGL2 message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.WEBGL2)).toMatch(/WebGL2/);
+  });
+
+  it('maps the colorBufferFloat reason to a float color buffer message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.COLOR_BUFFER_FLOAT)).toMatch(/float color buffer/i);
+  });
+
+  it('maps the shader reason to a shader-failure message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.SHADER)).toMatch(/shader/i);
+  });
+
+  it('falls back to a generic message for an unknown reason', () => {
+    expect(render3dErrorMessage('mystery')).toBe('3D rendering is unavailable (mystery).');
+  });
+});

--- a/web/src/engine/gl/render3dErrorMessage.test.js
+++ b/web/src/engine/gl/render3dErrorMessage.test.js
@@ -17,6 +17,10 @@ describe('render3dErrorMessage', () => {
     expect(render3dErrorMessage(RENDER_ERROR.COLOR_BUFFER_FLOAT)).toMatch(/float color buffer/i);
   });
 
+  it('maps the floatLinear reason to a float-linear filtering message', () => {
+    expect(render3dErrorMessage(RENDER_ERROR.FLOAT_LINEAR)).toMatch(/OES_texture_float_linear/);
+  });
+
   it('maps the shader reason to the exact shader-failure message', () => {
     expect(render3dErrorMessage(RENDER_ERROR.SHADER)).toBe('3D shaders failed to load.');
   });

--- a/web/src/engine/gl/render3dReadyState.js
+++ b/web/src/engine/gl/render3dReadyState.js
@@ -1,0 +1,20 @@
+import { RENDER_ERROR } from './gate3dCapability';
+
+export const SCENE_READY_TIMEOUT_MS = 10000;
+
+export function evaluateReadyState({ readyCounter, expectedCounter, materialsReady, elapsedMs, timeoutMs }) {
+  if (readyCounter === expectedCounter && materialsReady) {
+    return { ready: true, timedOut: false, error: RENDER_ERROR.NONE };
+  }
+  if (typeof elapsedMs === 'number' && typeof timeoutMs === 'number' && elapsedMs >= timeoutMs) {
+    return { ready: false, timedOut: true, error: RENDER_ERROR.SHADER };
+  }
+  return { ready: false, timedOut: false, error: RENDER_ERROR.NONE };
+}
+
+export function mapFramebufferStatus(status, completeValue) {
+  if (status === completeValue) {
+    return { ok: true, error: RENDER_ERROR.NONE };
+  }
+  return { ok: false, error: RENDER_ERROR.FRAMEBUFFER };
+}

--- a/web/src/engine/gl/render3dReadyState.test.js
+++ b/web/src/engine/gl/render3dReadyState.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateReadyState, mapFramebufferStatus, SCENE_READY_TIMEOUT_MS } from './render3dReadyState';
+import { RENDER_ERROR } from './gate3dCapability';
+
+describe('evaluateReadyState', () => {
+  const base = { readyCounter: 5, expectedCounter: 5, materialsReady: true, elapsedMs: 0, timeoutMs: SCENE_READY_TIMEOUT_MS };
+
+  it('is ready when counter reached and materials present', () => {
+    expect(evaluateReadyState(base)).toEqual({ ready: true, timedOut: false, error: RENDER_ERROR.NONE });
+  });
+
+  it('is not ready and not timed out while still within the timeout window', () => {
+    const r = evaluateReadyState({ ...base, readyCounter: 3, elapsedMs: 100 });
+    expect(r).toEqual({ ready: false, timedOut: false, error: RENDER_ERROR.NONE });
+  });
+
+  it('surfaces a shader error once the counter is stuck past the timeout', () => {
+    const r = evaluateReadyState({ ...base, readyCounter: 3, elapsedMs: SCENE_READY_TIMEOUT_MS });
+    expect(r).toEqual({ ready: false, timedOut: true, error: RENDER_ERROR.SHADER });
+  });
+
+  it('treats missing materials as not ready even when the counter is complete', () => {
+    const r = evaluateReadyState({ ...base, materialsReady: false, elapsedMs: 50 });
+    expect(r.ready).toBe(false);
+    expect(r.timedOut).toBe(false);
+  });
+
+  it('times out on complete counter but missing materials past the deadline', () => {
+    const r = evaluateReadyState({ ...base, materialsReady: false, elapsedMs: SCENE_READY_TIMEOUT_MS + 1 });
+    expect(r).toEqual({ ready: false, timedOut: true, error: RENDER_ERROR.SHADER });
+  });
+});
+
+describe('mapFramebufferStatus', () => {
+  const FRAMEBUFFER_COMPLETE = 0x8cd5;
+
+  it('reports ok when status equals the complete value', () => {
+    expect(mapFramebufferStatus(FRAMEBUFFER_COMPLETE, FRAMEBUFFER_COMPLETE)).toEqual({ ok: true, error: RENDER_ERROR.NONE });
+  });
+
+  it('reports a framebuffer error for any incomplete status', () => {
+    expect(mapFramebufferStatus(0x8cd6, FRAMEBUFFER_COMPLETE)).toEqual({ ok: false, error: RENDER_ERROR.FRAMEBUFFER });
+  });
+});

--- a/web/src/engine/gl/render3dReadyState.test.js
+++ b/web/src/engine/gl/render3dReadyState.test.js
@@ -29,6 +29,11 @@ describe('evaluateReadyState', () => {
     const r = evaluateReadyState({ ...base, materialsReady: false, elapsedMs: SCENE_READY_TIMEOUT_MS + 1 });
     expect(r).toEqual({ ready: false, timedOut: true, error: RENDER_ERROR.SHADER });
   });
+
+  it('does not time out when timing is not numeric (never surfaces a false shader error)', () => {
+    const r = evaluateReadyState({ ...base, readyCounter: 3, elapsedMs: undefined, timeoutMs: undefined });
+    expect(r).toEqual({ ready: false, timedOut: false, error: RENDER_ERROR.NONE });
+  });
 });
 
 describe('mapFramebufferStatus', () => {

--- a/web/src/engine/volumeFilter3d.js
+++ b/web/src/engine/volumeFilter3d.js
@@ -11,6 +11,7 @@
 import * as THREE from 'three';
 import MaterialBlur from './gfx/matblur';
 import GlSelector from './GlSelector';
+import { isWebGL2Context } from './gl/detect3dCapabilities';
 import AmbientTexture from './ambientTexture';
 import TransferTexture from './transferTexture';
 import Eraser from './Eraser';
@@ -38,6 +39,7 @@ export default class VolumeFilter3d {
     this.cameraOrtho = new THREE.OrthographicCamera(this.xDim / -2, this.xDim / 2, this.yDim / 2, this.yDim / -2, 0.1, 100);
     const glSelector = new GlSelector();
     this.context = glSelector.createWebGLContext();
+    this.isWebGL2 = isWebGL2Context(this.context) ? 1 : 0;
     this.canvas3d = glSelector.getCanvas();
     this.rendererBlur = new THREE.WebGLRenderer({
       canvas: this.canvas3d,
@@ -313,7 +315,6 @@ export default class VolumeFilter3d {
    * @return (object) Created texture
    */
   createUpdatableVolumeTex(volume, isRoiVolume, roiColors) {
-    this.isWebGL2 = 1;
     this.arrPixels = volume.m_dataArray;
     const xDim = volume.m_xDim;
     const yDim = volume.m_yDim;


### PR DESCRIPTION
Refs #208, #238

## Problem
Switching to 3D shows a **silent black screen** for some users/environments (#208 in a production build; #238 on Dev/Tst but not Prod). The 3D path fails without any message: capability/shader/framebuffer failures leave render targets null or the ready-counter incomplete, and the canvas is simply blank.

## Approach & scope
**#238 is environment-specific** (works on Prod, black on Dev/Tst) — the true root cause is most likely a deploy/CDN/asset difference that **cannot be reproduced from this repo alone**. This PR therefore delivers the *code-level* fixes: detect missing 3D capability and **surface a clear error instead of a black screen**, and re-enable a real framebuffer completeness check. That turns a silent black screen into an actionable diagnostic and closes the genuine capability-guard gaps behind #208. It does not (and cannot from here) fix any env/CDN misconfiguration behind #238 — hence `Refs`, not `Closes`.

## Fix
- New pure, unit-tested helpers under `web/src/engine/gl/`:
  - `detect3dCapabilities` — inspects the GL context for WebGL2, `EXT_color_buffer_float`, `OES_texture_float_linear`.
  - `gate3dCapability` — decides proceed/error from capabilities.
  - `render3dReadyState` — ready-state timeout + framebuffer-status mapping.
  - `render3dErrorMessage` — maps a reason to a user-facing message.
- `VolumeRenderer3d`: stop trusting a hardcoded `isWebGL2 = 1`; gate `initWithVolume` on real capability; on the missing-`EXT_color_buffer_float` branch set an error instead of leaving null targets; detect a stuck ready-state (10s) and re-enable a real `checkFramebufferStatus` check.
- `volumeFilter3d`: derive `isWebGL2` from the actual context (was hardcoded).
- `Graphics3d.jsx`: show a centered error overlay (`data-testid="graphics3d-render-error"`) with the specific reason instead of a blank canvas.

## Verification (in the running app, capable hardware, DPR 2)
- Real WebGL2 context reports `webgl2 + EXT_color_buffer_float + OES_texture_float_linear` all present → gate **proceeds** (no false block).
- Loaded a demo volume and switched to full 3D: console shows normal init (`WebGL 2 context created`, `3D tex size = 512 512 128`, `setBufferRgbaFrom1Bytes`), **no** `blocked` / `cant create float texture` / framebuffer / shader logs, and **no** error overlay — i.e. no regression on capable hardware.
- Engine unit suite green (43/0); full suite green (59/0) per plan run; lint clean on touched files.
- Note: making `OES_texture_float_linear` a hard requirement is intentional — float render targets sampled with linear filtering need it, so without it the original path would render black anyway; the guard now reports why.

## Follow-up (out of repo scope)
Reproduce #238 on Dev/Tst with the new diagnostic to confirm whether the missing capability/asset is the cause, and compare shader/asset loading Dev/Tst vs Prod (CDN config).
